### PR TITLE
Fix: Resolve FFmpeg dependency issue and add Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,23 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build_docker_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: sinatra:latest
+          push: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,5 +17,9 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - name: Install FFmpeg dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libavutil-dev libavformat-dev libavcodec-dev libswscale-dev libswresample-dev pkg-config
     - name: Run tests
       run: cargo test --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,19 @@
-FROM alpine:latest
+# 1. Change the base image to rust:latest
+FROM rust:latest
+
+# 2. Install FFmpeg development libraries
+RUN apt-get update && \
+    apt-get install -y libavutil-dev libavformat-dev libavcodec-dev libswscale-dev libswresample-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+# 3. Set the working directory
+WORKDIR /usr/src/app
+
+# 4. Copy project files
+COPY . .
+
+# 5. Build the Rust application in release mode
+RUN cargo build --release
+
+# 6. Set the CMD to execute the compiled application
+CMD ["/usr/src/app/target/release/sinatra"]


### PR DESCRIPTION
This commit addresses the build failure in the Rust CI pipeline caused by missing FFmpeg development libraries.

Key changes:
- Modified `.github/workflows/rust.yml` to install `libavutil-dev` and other required FFmpeg packages before running `cargo test`. This should fix the `pkg-config` error related to `libavutil`.
- Significantly enhanced the `Dockerfile`:
    - Switched to `rust:latest` base image.
    - Added steps to install FFmpeg development libraries within the Docker image.
    - Configured to copy application source code, build the Rust executable (named 'sinatra'), and set it as the default command.
- Added a new GitHub Action workflow in `.github/workflows/docker-build.yml`. This workflow automates the building of the Docker container whenever changes are pushed to the `master` branch. The image is tagged as `sinatra:latest` but is not pushed to a registry by default.

These changes ensure that the Rust tests can run successfully in the CI environment and provide a working Dockerfile to build and run the application in a containerized environment, along with a GitHub Action to automate the Docker build process.